### PR TITLE
500エラー画面を変更した

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,12 @@
 class ApplicationController < ActionController::Base
+  include SessionsHelper
+  before_action :logged_in_user
+
+  class ApplicationController < ActionController::Base
+    rescue_from StandardError, with: :rescue500
+
+    private def rescue500
+      render "errors/internal_server_error", status: 500
+    end
+  end
 end

--- a/app/views/errors/internal_server_error.html.erb
+++ b/app/views/errors/internal_server_error.html.erb
@@ -1,0 +1,4 @@
+<div id="error">
+  <h1>500 Internal Server Error</h1>
+  <p>ごめんね( *´艸｀)。システムエラーが発生したよ？。</p>
+</div>


### PR DESCRIPTION
* view/errors/internal_server_error.html.erbを追加しエラー時の表示を変更
* スタイルシートのerrorのスタイルを追加
* application_controller.rbに例外を補足する記述を追加
 - +6rescue_formでStandardErrorの例外（子孫含む）発生時rescue500に処理が移行する
 - +8privateとしてrescueの処理を追加
 - +9上記追加したviewにrenderするよう設定
  - status: 500 にてHTTPレスポンスのステータスコードを500に設定