### PR TITLE
Add categories

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -7,6 +7,13 @@ class Article < ApplicationRecord
   has_many :article_comments, dependent: :destroy
   # タイトル検索用メソッド
   has_many :favorites
+  #　カテゴリー
+  has_many :article_category_relations
+  has_many :article_categories, through: :article_category_relations
+  # 渡した配列に含まれているIDを持つ他の記事を探してくる
+  scope :category_id_in, -> article_category_ids {
+    joins(:article_categories).merge(ArticleCategory.id_in article_category_ids)
+  }
 
   def self.create_all_ranks # articleクラスからデータを取ってくる処理なのでクラスメソッド！
     Article.find(Favorite.group(:article_id).order('count(article_id) desc').limit(3).pluck(:article_id))

--- a/app/models/article_category.rb
+++ b/app/models/article_category.rb
@@ -1,0 +1,9 @@
+class ArticleCategory < ApplicationRecord
+  has_many :article_category_relations
+  # 中間テーブルのpost_category_relationsを経由して、関連付け
+  has_many :articles, through: :article_category_relations
+
+  scope :id_in, -> ids {
+    where(id: ids) if ids.present?
+  }
+end

--- a/app/models/article_category_relation.rb
+++ b/app/models/article_category_relation.rb
@@ -1,0 +1,4 @@
+class ArticleCategoryRelation < ApplicationRecord
+  belongs_to :article
+  belongs_to :article_category
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get '/article_categories/:id/show', to: "articles#category",  as: :category
 # Aboutページ
   root "top#index"
 

--- a/db/migrate/20200218061944_create_article_category_relations.rb
+++ b/db/migrate/20200218061944_create_article_category_relations.rb
@@ -1,0 +1,10 @@
+class CreateArticleCategoryRelations < ActiveRecord::Migration[5.2]
+  def change
+    create_table :article_category_relations do |t|
+      t.integer "article_id"
+      t.integer "article_category_id"
+      t.datetime "created_at", null: false
+      t.datetime "updated_at", null: false
+    end
+  end
+end

--- a/db/migrate/20200218062333_create_article_categories.rb
+++ b/db/migrate/20200218062333_create_article_categories.rb
@@ -1,0 +1,9 @@
+class CreateArticleCategories < ActiveRecord::Migration[5.2]
+  def change
+    create_table :article_categories do |t|
+      t.string "name"
+      t.datetime "created_at", null: false
+      t.datetime "updated_at", null: false
+    end
+  end
+end


### PR DESCRIPTION
### 記事のカテゴリー機能追加
* ArticleCategoryカテゴリーを追加
* ArticleCategoryRelation多対多の中間テーブルとして追加
* articlr.rbにhas_many :article_category_relations
  has_many :article_categories, through: :article_category_relationsを追記
* 記事カテゴリータグをクリックした先をcategory/actionとしてarticleコントローラーに追加