### PR TITLE
Add remember token

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  
   validates :name, presence: { message: 'が空欄だよ？' }
   validates :email, presence: { message: 'が空欄だよ？' }
   validates :password, presence: { message: 'きゃんとびいぶらんく☆' }
@@ -10,9 +11,14 @@ class User < ApplicationRecord
   has_many :favorites
 
   # 与えられた文字列のハッシュ値を返す
-  def User.digest(string)
+  def self.digest(string)
     cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST :
                                                   BCrypt::Engine.cost
     BCrypt::Password.create(string, cost: cost)
+  end
+  
+  # ランダムなトークン
+  def self.new_token
+    SecureRandom.urlsafe_base64
   end
 end


### PR DESCRIPTION
* 記憶トークとしてRuby標準ライブラリのSecureRandomモジュールにあるurlsafe_base64メソッドを使用
  * A–Z、a–z、0–9、“-”、“_”のいずれかの文字 (64種類) からなる長さ22のランダムな文字列を返す
* ユーザーを記憶するには、記憶トークンを作成してそのトークンをダイジェストに変換したものをデータベースに保存するためdigestメソッドを追加
* BCrypt::Password.create(string, cost: cost)
  * stringはハッシュ化する文字列、costはコストパラメータと呼ばれる値　現在低く設定
* ユーザーオブジェクトが不要なので、両メソッド、Userモデルのクラスメソッドとして作成