### PR TITLE
Add remember method

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,5 @@
 class User < ApplicationRecord
-  
+  attr_accessor :remember_token
   validates :name, presence: { message: 'が空欄だよ？' }
   validates :email, presence: { message: 'が空欄だよ？' }
   validates :password, presence: { message: 'きゃんとびいぶらんく☆' }
@@ -20,5 +20,11 @@ class User < ApplicationRecord
   # ランダムなトークン
   def self.new_token
     SecureRandom.urlsafe_base64
+  end
+
+  # 永続的セッションで使用するユーザーをデータベースに記憶する
+  def remember
+    self.remember_token = User.new_token
+    update_attribute(:remember_digest, User.digest(remember_token))
   end
 end


### PR DESCRIPTION
* 記憶トークンをユーザーと関連付け、トークンに対応する記憶ダイジェストをデータベースに保存するメソッドを追加
* データベースに保存せずに実装するためattr_accessorを使用してアクセス可能な属性を追加
* ローカル変数ではないためselfを使用
* update_attributeメソッドで記憶ダイジェストを更新させ、バリデーションに引っかからないようにする