### PR TITLE
Add remember user

### DIFF
--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -4,6 +4,13 @@ module SessionsHelper
     session[:user_id] = user.id
   end
 
+  # ユーザーを永続的セッションに記憶する
+  def remember(user)
+    user.remember
+    cookies.permanent.signed[:user_id] = user.id
+    cookies.permanent[:remember_token] = user.remember_token
+  end
+
   # 保存されたユーザーIDを元に、ユーザーの情報を取得
   def current_user
     if session[:user_id]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,4 +27,9 @@ class User < ApplicationRecord
     self.remember_token = User.new_token
     update_attribute(:remember_digest, User.digest(remember_token))
   end
+
+  # 渡されたトークンがダイジェストと一致したらtrueを返す
+  def authenticated?(remember_token)
+    BCrypt::Password.new(remember_digest).is_password?(remember_token)
+  end
 end


### PR DESCRIPTION
* user/modelに渡されたトークンがダイジェストと一致したらtrueを返すメソッドを追加
*sessions_helperにcookiesメソッドでユーザーIDと記憶トークンの永続cookiesを作成するメソッドを追加